### PR TITLE
Increase baseline version to one that sets 7 as its Java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
   <properties>
     <java.level>7</java.level>
-    <jenkins.version>1.612</jenkins.version>
+    <jenkins.version>1.625.3</jenkins.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
- java.level is set to 7.
- Jenkins 1.612 establishes java.level to 6.

@reviewbybees @stephenc 