### PR TITLE
Upgrade Parent POM to 3.2 and Jackson libs to 2.8.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.25</version>
+    <version>3.2</version>
   </parent>
 
   <artifactId>jackson2-api</artifactId>
-  <version>2.8.7.1-SNAPSHOT</version>
+  <version>2.8.10.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Jackson 2 API Plugin</name>
@@ -67,13 +67,13 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 
@@ -81,13 +81,13 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.10</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.10</version>
     </dependency>    
   </dependencies>
 </project>


### PR DESCRIPTION
Just an ongoing update of the library.

Changelogs:

- 2.8.8: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8.8
- 2.8.9: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8.9
- 2.8.10: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8.10

Full diff:
- https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.8.7...jackson-databind-2.8.10

@reviewbybees @stephenc @ndeloof 