### PR TITLE
Upgrade Jackson Databind to 2.9.5 to Address CVE CVE-2018-5968

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See also this [plugin's wiki page][wiki]
 
 The following build environment is required to build this plugin
 
-* `java-1.7` and `maven-3.0.5`
+* `java-1.8` and `maven-3.1.0`
 
 # Build
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.4</version>
+    <version>3.5</version>
   </parent>
 
   <artifactId>jackson2-api</artifactId>
-  <version>2.8.11.2-SNAPSHOT</version>
+  <version>2.9.5.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Jackson 2 API Plugin</name>
@@ -66,7 +66,7 @@
   <properties>
     <java.level>8</java.level>
     <jenkins.version>2.60.3</jenkins.version>
-    <jackson.version>2.8.11</jackson.version>
+    <jackson.version>2.9.5</jackson.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Need to upgrade jackson-databind (fasterxml) to 2.9.5 to resolve CVE-2018-5968