### PR TITLE
Update jackson-databind to 2.8.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,8 @@
     <java.level>8</java.level>
     <jenkins.version>2.60.3</jenkins.version>
     <jackson.version>2.8.11</jackson.version>
+    <!-- TODO: Unnecessary once we update to 2.9.x -->
+    <jackson-databind.version>2.8.11.1</jackson-databind.version>
   </properties>
 
   <repositories>
@@ -86,7 +88,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
+      <version>${jackson-databind.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Alternative to #6 (CC @bsteph) which addresses CVE-2018-5968 and CVE-2018-7489 without updating to the 2.9.x line. Note that the issues in question are related to an opt-in feature in Jackson that is not used in any open source Jenkins plugin or Jenkins itself, so it should not be a vulnerability in practice.

We should still look into upgrading to 2.9.x, but first we need to do some testing to make sure that that line is compatible with the 2.8.x line so that plugins depending on this plugin do not break.

[Upstream changelog](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8) (see 2.8.11.1 in micro-patches section).

@reviewbybees 
