### PR TITLE
Update to Jackson 2.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
     <jenkins.version>2.60.3</jenkins.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.9.9</jackson.version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.23</version>
+    <version>3.43</version>
   </parent>
 
   <artifactId>jackson2-api</artifactId>


### PR DESCRIPTION
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9

Notably, this includes a fix for CVE-2019-12086. See
FasterXML/jackson-databind#2326 for details.

@reviewbybees 