### PR TITLE
Update Jackson to 2.10.0.pr2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,12 @@
   </scm>
 
   <properties>
-    <revision>2.9.10</revision>
+    <revision>2.10.0-beta-1</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
     <jenkins.version>2.60.3</jenkins.version>
-    <jackson.version>2.9.9</jackson.version>
-    <jackson-databind.version>2.9.9.1</jackson-databind.version>
+    <jackson.version>2.10.0.pr2</jackson.version>
+    <jackson-databind.version>${jackson.version}</jackson-databind.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
This is a prerelease version of Jackson being made available as a beta
release plugin for Jenkins.