### PR TITLE
Move the plugin documentation from Wiki to GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,144 @@
+# Version History
+
+### 2.9.10
+
+Release date: (Sep 23, 2019)
+
+-   Update Jackson libraries to
+    [2.9.10](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.10).
+
+### 2.9.9
+
+Release date: (May 21, 2019)
+
+-   Update Jackson libraries to
+    [2.9.9](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9).
+
+### 2.9.8
+
+Release date: (Dec 17, 2018)
+
+-   Update Jackson libraries to
+    [2.9.8](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8).
+
+### 2.9.7.1
+
+Release date: (Nov 5, 2018)
+
+-   Non-beta release of Jackson
+    [2.9.7](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7)
+    as the baseline version for Jackson 2.x.
+
+### 2.9.7.0-beta
+
+Release date: (Oct 8, 2018)
+
+-   Update Jackson libraries to
+    [2.9.7](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7).
+
+### 2.8.11.3
+
+Release date: (Jun 4, 2018)
+
+-    Include [jackson-module-jaxb-annotations](https://github.com/FasterXML/jackson-modules-base/tree/master/jaxb)
+    in this plugin
+
+### 2.8.11.2
+
+Release date: (May 14, 2018)
+
+-    Update jackson-databind to 2.8.11.1
+
+### 2.8.11.1
+
+Release date: (Feb 09, 2018)
+
+-    Update Jackson libraries to 2.8.11
+
+### 2.8.10.1
+
+Release date: (2017/12/13)
+
+-   Update Jackson libraries to 2.8.10
+-   Update Parent POM to 3.2 and cleanup the discovered issues
+
+### 2.8.7.0
+
+Release date: (2017/10/9)
+
+-   Update Jackson to 2.8.7
+-   Update parent pom
+-   Increase baseline Java version to Java 8
+-   Increase baseline Jenkins version to 2.60
+
+### 2.7.3
+
+Release date: (2016/3/22)
+
+-   Update Jackson
+
+### 2.7.2
+
+Release date: (2016/3/22)
+
+-   Update Jackson
+
+### 2.7.1
+
+Release date: (2016/3/22)
+
+-   Update Jackson
+
+### 2.7.0 (2016/3/22)
+
+-   Update Jackson
+
+### 2.6.5
+
+Release date: (2016/3/22)
+
+-   Update Jackson
+
+### 2.6.4
+
+Release date: (2016/3/22)
+
+-   Update Jackson
+
+### 2.6.3
+
+Release date: (2016/3/22)
+
+-   Update Jackson
+
+### 2.6.2
+
+Release date: (2016/3/22)
+
+-   Update Jackson
+
+### 2.6.1
+
+Release date: (2016/3/22)
+
+-   Update Jackson
+
+### 2.6.0
+
+Release date: (2016/3/22)
+
+-   Update Jackson
+
+### 2.5.5
+
+Release date: (2016/3/22)
+
+-   Update to parent POM 2.x
+-   Also versions matching Jackson 2 versions: 2.6.0, 2.6.1, 2.6.2,
+    2.6.3, 2.6.4, 2.6.5, 2.7.0, 2.7.1, 2.7.2, 2.7.3
+
+### 2.5.4
+
+Release date: (2015/10/12)
+
+-   Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version History
 
+### Newer versions
+
+See [GitHub Releases](https://github.com/jenkinsci/jackson2-api-plugin/releases).
+
 ### 2.9.10
 
 Release date: (Sep 23, 2019)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@
 This plugin exposes the [FasterXML Jackson 2](https://github.com/FasterXML/jackson) API to Jenkins plugins.
 See [FasterXML Jackson Databind GitHub repo](https://github.com/FasterXML/jackson-databind) for more information.
 
-# Developer documentation
+## Changelog
+
+* See [GitHub Releases](https://github.com/jenkinsci/jackson2-api-plugin/releases) for recent versions
+* See [Release Notes](./CHANGELOG.md) for version 2.10.0 and older
+
+## Developer documentation
 
 See the [Jenkins Developer Documentation](https://jenkins.io/doc/developer/book/).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Jackson 2 API Plugin
 
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/jackson2-api.svg)](https://plugins.jenkins.io/jackson2-api)
+[![GitHub release](https://img.shields.io/github/release/jenkinsci/jackson2-api-plugin.svg?label=changelog)](https://github.com/jenkinsci/jackson2-api-plugin/releases/latest)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/jackson2-api.svg?color=blue)](https://plugins.jenkins.io/jackson2-api)
+
 This plugin exposes the [FasterXML Jackson 2](https://github.com/FasterXML/jackson) API to Jenkins plugins.
 See [FasterXML Jackson Databind GitHub repo](https://github.com/FasterXML/jackson-databind) for more information.
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,13 @@
 # Jackson 2 API Plugin
 
 This plugin exposes the [FasterXML Jackson 2](https://github.com/FasterXML/jackson) API to Jenkins plugins.
+See [FasterXML Jackson Databind GitHub repo](https://github.com/FasterXML/jackson-databind) for more information.
 
-See also this [plugin's wiki page][wiki]
+# Developer documentation
 
-# Environment
+See the [Jenkins Developer Documentation](https://jenkins.io/doc/developer/book/).
 
-The following build environment is required to build this plugin
+Cheatsheet:
 
-* `java-1.8` and `maven-3.3.9`
-
-# Build
-
-To build the plugin locally:
-
-    mvn clean verify
-
-# Release
-
-To release the plugin:
-
-    mvn release:prepare release:perform -B
-
-# Test local instance
-
-To test in a local Jenkins instance
-
-    mvn hpi:run
-
-  [wiki]: http://wiki.jenkins-ci.org/display/JENKINS/Jackson2+API+Plugin
+* To build the plugin locally: `mvn clean verify`
+* To test in a local Jenkins instance: `mvn hpi:run`

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <description>
     This plugin exposes the Jackson 2 JSON APIs to other Jenkins plugins.
   </description>
-  <url>https://wiki.jenkins.io/display/JENKINS/Jackson2+API+Plugin</url>
+  <url>https://github.com/jenkinsci/jackson2-api-plugin</url>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>


### PR DESCRIPTION
There is not a lot of Docs to move, but why not?