### PR TITLE
added dependency on jackson-annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
       <version>${jackson.version}</version>


### PR DESCRIPTION
I'm trying to tidy the dependencies management on a plugin which has several (indirect) dependencies on various Jackson libraries. Most of the upper-bound issues (for Jackson) can be successfully solved by adding a dependency on `jackson2-api` before the other involved dependencies.

But I'm still facing this error, for `jackson-annotations` (because there is no direct `jackson-annotations` dependency in `jackson2-api`):

```
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for com.fasterxml.jackson.core:jackson-annotations:2.9.5 paths to dependency are:
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jfrog.artifactory.client:artifactory-java-client-services:2.6.2
    +-com.fasterxml.jackson.core:jackson-annotations:2.9.5
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jenkins-ci.plugins:jackson2-api:2.11.1
    +-com.fasterxml.jackson.core:jackson-databind:2.11.1
      +-com.fasterxml.jackson.core:jackson-annotations:2.9.5
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jenkins-ci.plugins:jackson2-api:2.11.1
    +-com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.1
      +-com.fasterxml.jackson.core:jackson-annotations:2.11.1
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jenkins-ci.plugins:jackson2-api:2.11.1
    +-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
      +-com.fasterxml.jackson.core:jackson-annotations:2.11.1
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jfrog.buildinfo:build-info-extractor-nuget:2.19.2
    +-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
      +-com.fasterxml.jackson.core:jackson-annotations:2.11.1
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jfrog.artifactory.client:artifactory-java-client-services:2.6.2
    +-org.jfrog.artifactory.client:artifactory-java-client-api:2.6.2
      +-com.fasterxml.jackson.core:jackson-annotations:2.4.6
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.jfrog.artifactory.client:artifactory-java-client-services:2.6.2
    +-org.jfrog.artifactory.client:artifactory-java-client-httpClient:2.6.2
      +-com.fasterxml.jackson.core:jackson-annotations:2.4.6
and
+-org.jenkins-ci.plugins:artifactory:3.8.x-SNAPSHOT
  +-org.mock-server:mockserver-netty:5.10.0
    +-org.mock-server:mockserver-core:5.10.0
      +-com.fasterxml.jackson.core:jackson-annotations:2.10.1
```

One option would be to manage the `jackson-annotations` version explicitly (in the plugin I'm modifying), but I'd rather avoid that (one more dep version to maintain in the future, in addition to the `jackson2-api` version).
So I propose to add an explicit direct dependency on `jackson-annotations` in `jackson2-api` itself. The lib is already (indirectly) depended-on anyway, so it can't really hurt. And I've tested (with a local release, although actually based on 2.11.1 and not on master) that this change indeed makes maven-enforcer happy in this case.