### PR TITLE
Add jackson-datatype-json-org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-json-org</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    
+    <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-parameter-names</artifactId>
       <version>${jackson.version}</version>


### PR DESCRIPTION
jackson-datatype-json-org is used by pipeline-model-definition-plugin among others.