### PR TITLE
Add `jackson-dataformat-xml` to Jackson 2 API plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,12 @@
 
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>${jackson.version}</version>
       <exclusions>

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/XmlMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/XmlMapperTest.java
@@ -10,6 +10,8 @@ import org.jvnet.hudson.test.RealJenkinsRule;
 
 import java.nio.charset.StandardCharsets;
 
+import javax.xml.stream.XMLInputFactory;
+
 public class XmlMapperTest {
 
     @Rule public RealJenkinsRule rr = new RealJenkinsRule();
@@ -20,7 +22,11 @@ public class XmlMapperTest {
     }
 
     private static void _smokes(JenkinsRule r) throws Throwable {
-        XmlMapper mapper = new XmlMapper();
+        XMLInputFactory inputFactory =
+                XMLInputFactory.newFactory(
+                        XMLInputFactory.class.getName(), XmlFactory.class.getClassLoader());
+        XmlFactory factory = new XmlFactory(inputFactory);
+        XmlMapper mapper = new XmlMapper(factory);
         String content = "<foo><bar><id>123</id></bar></foo>";
         Foo foo = mapper.readValue(content.getBytes(StandardCharsets.UTF_8), Foo.class);
         assertNotNull(foo.getBar());

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/XmlMapperTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/XmlMapperTest.java
@@ -1,0 +1,53 @@
+package com.fasterxml.jackson.dataformat.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RealJenkinsRule;
+
+import java.nio.charset.StandardCharsets;
+
+public class XmlMapperTest {
+
+    @Rule public RealJenkinsRule rr = new RealJenkinsRule();
+
+    @Test
+    public void smokes() throws Throwable {
+        rr.then(XmlMapperTest::_smokes);
+    }
+
+    private static void _smokes(JenkinsRule r) throws Throwable {
+        XmlMapper mapper = new XmlMapper();
+        String content = "<foo><bar><id>123</id></bar></foo>";
+        Foo foo = mapper.readValue(content.getBytes(StandardCharsets.UTF_8), Foo.class);
+        assertNotNull(foo.getBar());
+        assertEquals("123", foo.getBar().getId());
+    }
+
+    static class Foo {
+        private Bar bar;
+
+        public Bar getBar() {
+            return bar;
+        }
+
+        public void setBar(Bar bar) {
+            this.bar = bar;
+        }
+    }
+
+    static class Bar {
+        private String id;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+}


### PR DESCRIPTION
Adds `jackson-dataformat-xml` to the Jackson 2 API plugin for the benefit of other plugins that need it and want to get it through the Jackson 2 API plugin. This also bundles the following two new transitive dependencies:

```
[WARNING] Bundling transitive dependency woodstox-core-6.2.4.jar (via jackson-dataformat-xml)
[WARNING] Bundling transitive dependency stax2-api-4.2.1.jar (via jackson-dataformat-xml)
```

These are up-to-date versions of StAX 2 (which the Java Platform does not provide) and Woodstox (the recommended StAX implementation for `jackson-dataformat-xml`.

I included a new integration test with `RealJenkinsRule` that works against Jenkins 2.297 and earlier, as well as tip-of-trunk with jenkinsci/jenkins#5604. Without jenkinsci/jenkins#5604, the test fails on tip-of-trunk with the same error as in jenkinsci/azure-storage-plugin#194. So somehow we end up relying on the old version of Woodstox (3.x) from Jenkins core, even though `jackson-dataformat-xml` depends on a recent version of Woodstox as a compile-time dependency. I am not sure why. The test passes with regular `JenkinsRule`, so this must be a classpath issue with `jenkins.war`. This would be a useful starting point for anyone who is investigating removing Woodstox from Jenkins core.

CC @timja 