### PR TITLE
do not bundle a library whose classes are already provideded by core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <revision>2.12.5</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
-    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.version>2.249.1</jenkins.version>
     <jackson.version>2.12.4</jackson.version>
     <jackson-databind.version>${jackson.version}</jackson-databind.version>
   </properties>
@@ -89,8 +89,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.222.x</artifactId>
-        <version>887.vae9c8ac09ff7</version>
+        <artifactId>bom-2.249.x</artifactId>
+        <version>966.v3857b7c82032</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -144,6 +144,17 @@
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
       <version>${jackson.version}</version>
+      <exclusions>
+        <exclusion>
+          <!--
+            Jenkins core ships jakarta.activation:jakarta.activation (ie the impl which contains both api and impl classes) version 1.2.1
+            since https://github.com/jenkinsci/jenkins/pull/4660 via transitive dependency on jakarta-mail
+            Need to be careful here if the annotations (or core) pick up newer versions that change the package names.
+          -->
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
   </scm>
 
   <properties>
-    <revision>2.12.4-1</revision>
+    <revision>${jackson.version}-1</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
     <jenkins.version>2.249.1</jenkins.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
   </scm>
 
   <properties>
-    <revision>2.12.5</revision>
+    <revision>2.12.4-1</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
     <jenkins.version>2.249.1</jenkins.version>


### PR DESCRIPTION
the activation framework classes are already provided by core.

Prior to jenkins-2.235 they where patched 1.1.1 versions but since
https://github.com/jenkinsci/jenkins/commit/abb131073ac06b2129cbda860c53d4720402a47f
it is the 1.2.1 version transitively from jakarta.mail

As the plugin is neither using plugin first classloader nor the
mask-classes approach this is just bloat - so remove it.

bumps the parent version and the minimum jenkins baseline to be > 2.235
to ensure we do get at least a 1.2.x version

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
