### PR TITLE
Add `jackson-jaxrs-json-provider`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <version>${revision}</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>snakeyaml-api</artifactId>
     </dependency>


### PR DESCRIPTION
This is used by the [GitLab](https://plugins.jenkins.io/gitlab-plugin/) plugin, so it would be nice to have it included in the Jackson 2 API plugin.