### PR TITLE
Fix `JacksonJsonProvider`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,11 @@
       <artifactId>jackson-jaxrs-json-provider</artifactId>
       <version>${revision}</version>
     </dependency>
+    <dependency> <!-- needed for jackson-jaxrs-json-provider -->
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>jakarta.ws.rs-api</artifactId>
+        <version>2.1.6</version> <!-- do not upgrade to version 3.x, as that has switched to Jakarta package names -->
+    </dependency>
 
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/src/test/java/com/fasterxml/jackson/jaxrs/json/JacksonJsonProviderTest.java
+++ b/src/test/java/com/fasterxml/jackson/jaxrs/json/JacksonJsonProviderTest.java
@@ -1,0 +1,15 @@
+package com.fasterxml.jackson.jaxrs.json;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.RealJenkinsRule;
+
+public class JacksonJsonProviderTest {
+
+    @Rule public RealJenkinsRule rr = new RealJenkinsRule();
+
+    @Test
+    public void smokes() throws Throwable {
+        rr.then(j -> new JacksonJsonProvider());
+    }
+}


### PR DESCRIPTION
Fixes jenkinsci/gitlab-plugin#1206 by bundling the JAX-RS API JAR in the Jackson 2 API plugin. The new `RealJenkinsRule`-based test fails before this PR and passes with it. I have also written a functional test in jenkinsci/gitlab-plugin#1207 which fails before this PR and passes with it.