### PR TITLE
Use Jersey 2 API plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,9 +185,10 @@
       <version>${revision}</version>
     </dependency>
     <dependency> <!-- needed for jackson-jaxrs-json-provider -->
-        <groupId>jakarta.ws.rs</groupId>
-        <artifactId>jakarta.ws.rs-api</artifactId>
-        <version>2.1.6</version> <!-- do not upgrade to version 3.x, as that has switched to Jakarta package names -->
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>jersey2-api</artifactId>
+        <version>2.35-1</version>
+        <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
#107 added `jackson-jaxrs-json-provider`, which exposed the need for the JAX-RS API. That was added in #111, which exposed the need for a JAX-RS implementation. Since a JAX-RS API and implementation are outside the scope of this plugin, I have created a new [Jersey 2 API plugin](https://github.com/jenkinsci/jersey2-api-plugin/) providing the [JAX-RS 2.1](https://jcp.org/en/jsr/detail?id=370) API with [Jersey 2](https://eclipse-ee4j.github.io/jersey/) as its implementation. This PR adjusts the Jackson 2 API plugin to consume that new plugin as an optional dependency.