### PR TITLE
Bump parent POM from 4.37 to 4.38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.37</version>
+    <version>4.38</version>
   </parent>
 
   <artifactId>jackson2-api</artifactId>


### PR DESCRIPTION
Needed for Java 17 testing of plugin BOM, so a release would be appreciated. CC @jtnord 