### PR TITLE
Revert "remove java8 build"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 buildPlugin(configurations: [
-        [ platform: "windows", jdk: "11", jenkins: null ],
+        [ platform: "linux", jdk: "8", jenkins: null ],
+        [ platform: "windows", jdk: "8", jenkins: null ],
         [ platform: "linux", jdk: "11", jenkins: null ]
 ])


### PR DESCRIPTION
Reverts jenkinsci/jackson2-api-plugin#172

Actually best not to do this - Jenkins the version we target uses java8 and as this is an API plugin that *may* contain some security issue that we need to release for (jackson may not provide backports) I think it is better to keep the status quo.