### PR TITLE
[JENKINS-75276] ensure ASM licence is attributes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
+    <license>
+      <!-- for the ASM library that byte-buddy shades JENKINS-75276 -->
+      <name>BSD 3-Clause ASM</name>
+      <url>https://gitlab.ow2.org/asm/asm/raw/ASM_9_7_1/LICENSE.txt</url>
+    </license>
   </licenses>
 
   <developers>


### PR DESCRIPTION
the byte-buddy library includes a shaded ASM lib, but there was no attribution of this in the plugin.

https://github.com/jenkinsci/jackson2-api-plugin/pull/267#issuecomment-2656029762
https://issues.jenkins.io/browse/JENKINS-75276

<!-- Please describe your pull request here. -->

### Testing done

None

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
