### PR TITLE
Revert "Use Byte Buddy library plugin where possible"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
+    <license>
+      <!-- for the ASM library that byte-buddy shades JENKINS-75276 -->
+      <name>BSD 3-Clause ASM</name>
+      <url>https://gitlab.ow2.org/asm/asm/raw/ASM_9_7_1/LICENSE.txt</url>
+    </license>
   </licenses>
 
   <developers>
@@ -67,9 +72,7 @@
   <properties>
     <revision>2.17.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.462</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.version>2.401.3</jenkins.version>
   </properties>
 
   <repositories>
@@ -96,8 +99,8 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4228.v0a_71308d905b_</version>
+        <artifactId>bom-2.401.x</artifactId>
+        <version>2745.vc7b_fe4c876fa_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -108,13 +111,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <exclusions>
-        <!-- Provided by byte-buddy-api plugin -->
-        <exclusion>
-          <groupId>net.bytebuddy</groupId>
-          <artifactId>byte-buddy</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -195,11 +191,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-toml</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>byte-buddy-api</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Reverts jenkinsci/jackson2-api-plugin#267

jackson2 does not actually need byte-buddy.  this was an error upstream that was fixed in https://github.com/FasterXML/jackson-databind/pull/4491  (in 2.18)
So until we pick up that version lets not force the install of a plugin that would then be dangling when it is about to be removed. (quick fix just to prevent users getting the last release)