### PR TITLE
Revert "Bump com.fasterxml.jackson:jackson-bom from 2.18.3 to 2.19.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
   </scm>
 
   <properties>
-    <revision>2.19.0</revision>
+    <revision>2.18.3</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>


### PR DESCRIPTION
Reverts jenkinsci/jackson2-api-plugin#284

See https://github.com/jenkinsci/bom/pull/5114

This keeps the main branch releasable at all times, a desirable property in case we need to release parent POM updates for PCT purposes or other reasons.

I'm intentionally not doing anything special with the version number here to avoid introducing technical debt. Users who have already upgraded won't get any new 2.18.x releases, but because we've stopped distribution of 2.19.x on the update center, those users should be very few.