### PR TITLE
Rely on annotations plugin instead of bundling annotations jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
-    <hpi.bundledArtifacts>jackson-annotations,jackson-core,jackson-databind,jackson-dataformat-cbor,jackson-dataformat-csv,jackson-dataformat-toml,jackson-dataformat-xml,jackson-dataformat-yaml,jackson-datatype-jdk8,jackson-datatype-json-org,jackson-datatype-jsr310,jackson-module-jakarta-xmlbind-annotations,jackson-module-jaxb-annotations,jackson-module-parameter-names</hpi.bundledArtifacts>
+    <hpi.bundledArtifacts>jackson-core,jackson-databind,jackson-dataformat-cbor,jackson-dataformat-csv,jackson-dataformat-toml,jackson-dataformat-xml,jackson-dataformat-yaml,jackson-datatype-jdk8,jackson-datatype-json-org,jackson-datatype-jsr310,jackson-module-jakarta-xmlbind-annotations,jackson-module-jaxb-annotations,jackson-module-parameter-names</hpi.bundledArtifacts>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
@@ -126,6 +126,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jackson-annotations2-api</artifactId>
+      <version>2.21-7.v4777a_f3a_a_d47</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
@@ -160,11 +166,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Rely on annotations plugin instead of bundling annotations jar

Part of the fix for issue:

* https://github.com/jenkinsci/jackson3-api-plugin/issues/41

Uses newly released annotations plugin from pull request:

* https://github.com/jenkins-infra/repository-permissions-updater/pull/5027

Part of the fix for Jenkins Jira issues:

* https://issues.jenkins.io/browse/JENKINS-76435
* https://issues.jenkins.io/browse/JENKINS-76437

### Testing done

* Confirmed that tests pass locally
* Pre-release build confirmed that it fixes issue
  https://github.com/jenkinsci/jackson3-api-plugin/issues/41

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
