### PR TITLE
Update to 2.22.0 and combinate several deps update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>6.2138.v03274d462c13</version>
+    <version>6.2189.v695a_c41f5249</version>
     <relativePath />
   </parent>
 
@@ -70,7 +70,7 @@
   </scm>
 
   <properties>
-    <revision>2.21.2</revision>
+    <revision>2.22.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
@@ -78,6 +78,7 @@
     <hpi.bundledArtifacts>jackson-core,jackson-databind,jackson-dataformat-cbor,jackson-dataformat-csv,jackson-dataformat-toml,jackson-dataformat-xml,jackson-dataformat-yaml,jackson-datatype-jdk8,jackson-datatype-json-org,jackson-datatype-jsr310,jackson-module-jakarta-xmlbind-annotations,jackson-module-jaxb-annotations,jackson-module-parameter-names</hpi.bundledArtifacts>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
+    <banObsoleteDependencyOverrides.skip>false</banObsoleteDependencyOverrides.skip>
   </properties>
 
   <repositories>
@@ -113,13 +114,25 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>jakarta-xml-bind-api</artifactId>
-        <version>4.0.5-3.v3d5b_a_73965b_9</version>
+        <version>4.0.6-12.vb_1833c1231d3</version>
       </dependency>
       <!-- TODO until in BOM -->
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>woodstox-core-api</artifactId>
-        <version>7.1.1-1.v4d297985f397</version>
+        <version>7.2.1-6.v3718a_a_11f5c4</version>
+      </dependency>
+      <!-- TODO until in BOM -->
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>jackson-annotations2-api</artifactId>
+        <version>2.22-19.v10a_a_582ea_26e</version>
+      </dependency>
+      <!-- TODO until in BOM -->
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>jakarta-activation-api</artifactId>
+        <version>2.1.4-1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -128,12 +141,18 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jackson-annotations2-api</artifactId>
-      <version>2.21-7.v4777a_f3a_a_d47</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <exclusions>
+        <!-- Provided by jackson-annotations2-api plugin -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -215,15 +234,21 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
-      <!-- Provided by woodstox-core API plugin -->
       <exclusions>
+        <!-- Provided by woodstox-core API plugin -->
         <exclusion>
           <groupId>com.fasterxml.woodstox</groupId>
           <artifactId>woodstox-core</artifactId>
         </exclusion>
+        <!-- Provided by woodstox-core API plugin -->
         <exclusion>
           <groupId>org.codehaus.woodstox</groupId>
           <artifactId>stax2-api</artifactId>
+        </exclusion>
+        <!-- Provided by jackson-annotations2-api plugin -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
     <revision>2.22.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.baseline>2.528</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <hpi.bundledArtifacts>jackson-core,jackson-databind,jackson-dataformat-cbor,jackson-dataformat-csv,jackson-dataformat-toml,jackson-dataformat-xml,jackson-dataformat-yaml,jackson-datatype-jdk8,jackson-datatype-json-org,jackson-datatype-jsr310,jackson-module-jakarta-xmlbind-annotations,jackson-module-jaxb-annotations,jackson-module-parameter-names</hpi.bundledArtifacts>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
@@ -106,33 +106,9 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4136.vca_c3202a_7fd1</version>
+        <version>6607.v3ed3d8ddfed8</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <!-- TODO until in BOM -->
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>jakarta-xml-bind-api</artifactId>
-        <version>4.0.6-12.vb_1833c1231d3</version>
-      </dependency>
-      <!-- TODO until in BOM -->
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>woodstox-core-api</artifactId>
-        <version>7.2.1-6.v3718a_a_11f5c4</version>
-      </dependency>
-      <!-- TODO until in BOM -->
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>jackson-annotations2-api</artifactId>
-        <version>2.22-19.v10a_a_582ea_26e</version>
-      </dependency>
-      <!-- TODO until in BOM -->
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>jakarta-activation-api</artifactId>
-        <version>2.1.4-1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Update to 2.22.0 and combinate several deps update

+ move some override to dependencyManagement
+ add missing exclusion for jackson annotation
+ parent update with `banObsoleteDependencyOverrides.skip` 

Supersedes 

https://github.com/jenkinsci/jackson2-api-plugin/pull/343
https://github.com/jenkinsci/jackson2-api-plugin/pull/342
https://github.com/jenkinsci/jackson2-api-plugin/pull/341

### Testing done

mvn clean install only

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed


